### PR TITLE
feat: make font size configurable on android

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -19,12 +19,13 @@
     "karma": "4.1.0",
     "karma-jasmine": "2.0.1",
     "karma-nativescript-launcher": "^0.4.0",
+    "karma-webpack": "3.0.5",
     "nativescript-css-loader": "~0.26.1",
     "nativescript-dev-webpack": "1.0.1",
     "tns-platform-declarations": "6.0.1",
     "tslint": "~5.12.1",
     "typescript": "3.4.5",
-    "karma-webpack": "3.0.5"
+    "uglifyjs-webpack-plugin": "^2.2.0"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm i && npm run build",

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -1,29 +1,36 @@
-import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
-
+import { fontSizeProperty, markdownProperty, MarkdownViewBase } from './markdown-view.common';
+​
 declare var ru: any;
-
+​
 export class MarkdownView extends MarkdownViewBase {
-
+​
     _android: any = null; // android.widget.TextView
-
+​
     markwon: any;
-
+​
+    private _fontSize = 14;
+​
     constructor() {
         super();
     }
-
+​
     get android(): android.widget.TextView {
         return this._android;
     }
-
+​
     public createNativeView() {
         this.markwon = ru.noties.markwon.Markwon.create(this._context);
         this._android = new android.widget.TextView(this._context);
         return this._android;
     }
-
+​
+    [fontSizeProperty.setNative](size: number) {
+        this._fontSize = size;
+    }
+​
     [markdownProperty.setNative](markdown: string) {
+        this._android.setTextSize(Number(this._fontSize));
         this.markwon.setMarkdown(this.nativeView, markdown);
     }
-
+​
 }

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -1,4 +1,6 @@
 import { fontSizeProperty, markdownProperty, MarkdownViewBase } from './markdown-view.common';
+import InputType = android.text.InputType;
+
 ​
 declare var ru: any;
 ​
@@ -8,7 +10,7 @@ export class MarkdownView extends MarkdownViewBase {
 ​
     markwon: any;
 ​
-    private _fontSize = 14;
+    private _fontSize = 18;
 ​
     constructor() {
         super();
@@ -21,6 +23,7 @@ export class MarkdownView extends MarkdownViewBase {
     public createNativeView() {
         this.markwon = ru.noties.markwon.Markwon.create(this._context);
         this._android = new android.widget.TextView(this._context);
+        this._android.setInputType(InputType.TYPE_NULL);
         return this._android;
     }
 ​

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -26,6 +26,7 @@ export class MarkdownView extends MarkdownViewBase {
 ​
     [fontSizeProperty.setNative](size: number) {
         this._fontSize = size;
+        this._android.setTextSize(Number(this._fontSize));
     }
 ​
     [markdownProperty.setNative](markdown: string) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-markdown-view",
-    "version": "1.1.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.

## What is the current behavior?
Currently font size is configurable only on iOS platforms

## What is the new behavior?
Adds possibility to configure font size for Android platform.

