### PR TITLE
fix: Uses existing font size property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     node_js: '10'
     jdk: oraclejdk8
     script:
-    - cd src && npm i && npm run tsc && cd ../demo && tns build ios
+    - pod repo update && cd src && npm i && npm run tsc && cd ../demo && tns build ios
   - stage: deploy
     language: node_js
     os: linux

--- a/demo/app/app.css
+++ b/demo/app/app.css
@@ -1,1 +1,9 @@
 ﻿@import '~nativescript-theme-core/css/core.light.css';
+
+.large {
+    font-size: 18;
+}
+
+.small {
+    font-size: 12;
+}

--- a/demo/app/app.css
+++ b/demo/app/app.css
@@ -1,4 +1,4 @@
-﻿@import '~nativescript-theme-core/css/core.light.css';
+﻿@import '~@nativescript/theme/css/core.css';
 
 .large {
     font-size: 18;

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -4,7 +4,7 @@ You can use this file to perform app-level initialization, but the primary
 purpose of the file is to pass control to the app’s first module.
 */
 
-import * as app from "tns-core-modules/application";
+import * as app from "@nativescript/core/application";
 
 app.run({ moduleName: "app-root" });
 

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -1,5 +1,5 @@
-import * as observable from 'tns-core-modules/data/observable';
-import * as pages from 'tns-core-modules/ui/page';
+import * as observable from '@nativescript/core/data/observable';
+import * as pages from '@nativescript/core/ui/page';
 import { HelloWorldModel } from './main-view-model';
 
 // Event handler for Page 'loaded' event attached in main-page.xml

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -2,26 +2,27 @@
       xmlns:mv="nativescript-markdown-view">
     <ScrollView>
         <FlexboxLayout class="p-20" flexDirection="column">
-            <Label text="Text" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Text" style="margin-top: 10; margin-bottom: 10;"/>
+            <mv:MarkdownView textWrap="true" markdown="{{text}}" class="large"/>
             <mv:MarkdownView textWrap="true" markdown="{{text}}"/>
-            <mv:MarkdownView textWrap="true" markdown="{{text}}" fontSize="12"/>
+            <mv:MarkdownView textWrap="true" markdown="{{text}}" class="small"/>
 
-            <Label text="Headings" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Headings" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{headings}}"/>
 
-            <Label text="Emphasis" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Emphasis" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{emphasis}}"/>
 
-            <Label text="Lists" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Lists" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{lists}}"/>
 
-            <Label text="Link" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Link" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{link}}"/>
 
-            <Label text="Quote" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Quote" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{quote}}"/>
 
-            <Label text="Code" style="margin-top: 10; margin-bottom: 10;"/>
+            <Label class="h1" text="Code" style="margin-top: 10; margin-bottom: 10;"/>
             <mv:MarkdownView textWrap="true" markdown="{{code}}"/>
         </FlexboxLayout>
     </ScrollView>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'tns-core-modules/data/observable';
+import { Observable } from '@nativescript/core/data/observable';
 
 export class HelloWorldModel extends Observable {
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "nativescript-markdown-view": "file:../src",
     "@nativescript/theme": "~2.2.0",
-    "tns-core-modules": "~6.2.0"
+    "tns-core-modules": "6.2.1",
+    "@nativescript/core": "6.2.1"
   },
   "devDependencies": {
     "nativescript-dev-webpack": "~1.3.0",
-    "typescript": "~3.5.3",
-    "tslint": "~5.12.1"
+    "nativescript-unit-test-runner": "^0.7.0",
+    "tslint": "~5.12.1",
+    "typescript": "~3.5.3"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm i && npm run build",

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,22 +10,12 @@
   },
   "dependencies": {
     "nativescript-markdown-view": "file:../src",
-    "nativescript-theme-core": "^1.0.4",
-    "nativescript-unit-test-runner": "0.7.0",
-    "tns-core-modules": "6.0.1"
+    "@nativescript/theme": "~2.2.0",
+    "tns-core-modules": "~6.2.0"
   },
   "devDependencies": {
-    "jasmine-core": "^2.5.2",
-    "karma": "4.1.0",
-    "karma-jasmine": "2.0.1",
-    "karma-nativescript-launcher": "^0.4.0",
-    "karma-webpack": "3.0.5",
-    "nativescript-css-loader": "~0.26.1",
-    "nativescript-dev-webpack": "1.0.1",
-    "tns-platform-declarations": "6.0.1",
-    "tslint": "~5.12.1",
-    "typescript": "3.4.5",
-    "uglifyjs-webpack-plugin": "^2.2.0"
+    "nativescript-dev-webpack": "~1.3.0",
+    "typescript": "~3.5.3"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm i && npm run build",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "nativescript-dev-webpack": "~1.3.0",
-    "typescript": "~3.5.3"
+    "typescript": "~3.5.3",
+    "tslint": "~5.12.1"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm i && npm run build",

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -3,11 +3,13 @@ const { join, relative, resolve, sep } = require("path");
 const webpack = require("webpack");
 const nsWebpack = require("nativescript-dev-webpack");
 const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
+const { getNoEmitOnErrorFromTSConfig } = require("nativescript-dev-webpack/utils/tsconfig-utils");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
-const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 const hashSalt = Date.now().toString();
 
 module.exports = env => {
@@ -27,37 +29,59 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
-        // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
+        // the nsconfig.json configuration file.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 
         // You can provide the following flags when running 'tns run android|ios'
         snapshot, // --env.snapshot
+        production, // --env.production
         uglify, // --env.uglify
         report, // --env.report
         sourceMap, // --env.sourceMap
+        hiddenSourceMap, // --env.hiddenSourceMap
         hmr, // --env.hmr,
-        unitTesting, // --env.unitTesting
+        unitTesting, // --env.unitTesting,
+        verbose, // --env.verbose
+        snapshotInDocker, // --env.snapshotInDocker
+        skipSnapshotTools, // --env.skipSnapshotTools
+        compileSnapshot // --env.compileSnapshot
     } = env;
+
+    const useLibs = compileSnapshot;
+    const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
 
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
 
-    const entryModule = nsWebpack.getEntryModule(appFullPath);
+    const entryModule = nsWebpack.getEntryModule(appFullPath, platform);
     const entryPath = `.${sep}${entryModule}.ts`;
     const entries = { bundle: entryPath };
-    if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+
+    const tsConfigPath = resolve(projectRoot, "tsconfig.tns.json");
+
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
+    let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);
+
+    const itemsToClean = [`${dist}/**/*`];
+    if (platform === "android") {
+        itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "src", "main", "assets", "snapshots")}`);
+        itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "build", "configurations", "nativescript-android-snapshot")}`);
+    }
+
+    const noEmitOnErrorFromTSConfig = getNoEmitOnErrorFromTSConfig(tsConfigPath);
+
+    nsWebpack.processAppComponents(appComponents, platform);
     const config = {
-        mode: uglify ? "production" : "development",
+        mode: production ? "production" : "development",
         context: appFullPath,
         externals,
         watchOptions: {
@@ -72,6 +96,7 @@ module.exports = env => {
         output: {
             pathinfo: false,
             path: dist,
+            sourceMapFilename,
             libraryTarget: "commonjs2",
             filename: "[name].js",
             globalObject: "global",
@@ -104,9 +129,10 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: sourceMap ? "inline-source-map" : "none",
+        devtool: hiddenSourceMap ? "hidden-source-map" : (sourceMap ? "inline-source-map" : "none"),
         optimization: {
             runtimeChunk: "single",
+            noEmitOnErrors: noEmitOnErrorFromTSConfig,
             splitChunks: {
                 cacheGroups: {
                     vendor: {
@@ -124,12 +150,14 @@ module.exports = env => {
             },
             minimize: !!uglify,
             minimizer: [
-                new UglifyJsPlugin({
+                new TerserPlugin({
                     parallel: true,
                     cache: true,
-                    uglifyOptions: {
+                    sourceMap: isAnySourceMapEnabled,
+                    terserOptions: {
                         output: {
                             comments: false,
+                            semicolons: !isAnySourceMapEnabled
                         },
                         compress: {
                             // The Android SBG has problems parsing the output
@@ -144,7 +172,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {
@@ -159,37 +187,28 @@ module.exports = env => {
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,
+                                ignoredFiles: nsWebpack.getUserDefinedEntries(entries, platform)
                             }
                         },
                     ].filter(loader => !!loader)
                 },
 
                 {
-                    test: /-page\.ts$/,
-                    use: "nativescript-dev-webpack/script-hot-loader"
-                },
-
-                {
-                    test: /\.(css|scss)$/,
-                    use: "nativescript-dev-webpack/style-hot-loader"
-                },
-
-                {
-                    test: /\.(html|xml)$/,
-                    use: "nativescript-dev-webpack/markup-hot-loader"
+                    test: /\.(ts|css|scss|html|xml)$/,
+                    use: "nativescript-dev-webpack/hmr/hot-loader"
                 },
 
                 { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader" },
 
                 {
                     test: /\.css$/,
-                    use: { loader: "css-loader", options: { minimize: false, url: false } }
+                    use: "nativescript-dev-webpack/css2json-loader"
                 },
 
                 {
                     test: /\.scss$/,
                     use: [
-                        { loader: "css-loader", options: { minimize: false, url: false } },
+                        "nativescript-dev-webpack/css2json-loader",
                         "sass-loader"
                     ]
                 },
@@ -199,10 +218,14 @@ module.exports = env => {
                     use: {
                         loader: "ts-loader",
                         options: {
-                            configFile: "tsconfig.tns.json",
+                            configFile: tsConfigPath,
+                            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#faster-builds
+                            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#hot-module-replacement
+                            transpileOnly: true,
                             allowTsInNodeModules: true,
                             compilerOptions: {
-                                sourceMap
+                                sourceMap: isAnySourceMapEnabled,
+                                declaration: false
                             }
                         },
                     }
@@ -213,27 +236,17 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
-                "process": undefined,
+                "process": "global.process",
             }),
             // Remove all files from the out dir.
-            new CleanWebpackPlugin([`${dist}/**/*`]),
+            new CleanWebpackPlugin(itemsToClean, { verbose: !!verbose }),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
                 { from: { glob: "**/*.jpg" } },
                 { from: { glob: "**/*.png" } },
             ], { ignore: [`${relative(appPath, appResourcesFullPath)}/**`] }),
-            // Generate a bundle starter script and activate it in package.json
-            new nsWebpack.GenerateBundleStarterPlugin(
-                // Don't include `runtime.js` when creating a snapshot. The plugin
-                // configures the WebPack runtime to be generated inside the snapshot
-                // module and no `runtime.js` module exist.
-                (snapshot ? [] : ["./runtime"])
-                    .concat([
-                        "./vendor",
-                        "./bundle",
-                    ])
-            ),
+            new nsWebpack.GenerateNativeScriptEntryPointsPlugin("bundle"),
             // For instructions on how to set up workers with webpack
             // check out https://github.com/nativescript/worker-loader
             new NativeScriptWorkerPlugin(),
@@ -243,20 +256,17 @@ module.exports = env => {
             }),
             // Does IPC communication with the {N} CLI to notify events when running in watch mode.
             new nsWebpack.WatchStateLoggerPlugin(),
+            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#faster-builds
+            // https://github.com/TypeStrong/ts-loader/blob/ea2fcf925ec158d0a536d1e766adfec6567f5fb4/README.md#hot-module-replacement
+            new ForkTsCheckerWebpackPlugin({
+                tsconfig: tsConfigPath,
+                async: false,
+                useTypescriptIncrementalApi: true,
+                checkSyntacticErrors: true,
+                memoryLimit: 4096
+            })
         ],
     };
-
-    // Copy the native app resources to the out dir
-    // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (!externals || externals.length === 0) {
-        config.plugins.push(new CopyWebpackPlugin([
-            {
-                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                context: projectRoot
-            },
-        ]));
-    }
 
     if (report) {
         // Generate report files for bundles content
@@ -277,6 +287,9 @@ module.exports = env => {
             ],
             projectRoot,
             webpackConfig: config,
+            snapshotInDocker,
+            skipSnapshotTools,
+            useLibs
         }));
     }
 

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -1,4 +1,4 @@
-import { fontSizeProperty, markdownProperty, MarkdownViewBase } from './markdown-view.common';
+import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
 import InputType = android.text.InputType;
 
 ​
@@ -9,9 +9,7 @@ export class MarkdownView extends MarkdownViewBase {
     _android: any = null; // android.widget.TextView
 ​
     markwon: any;
-​
-    private _fontSize = 18;
-​
+​​
     constructor() {
         super();
     }
@@ -27,13 +25,15 @@ export class MarkdownView extends MarkdownViewBase {
         return this._android;
     }
 ​
-    [fontSizeProperty.setNative](size: number) {
-        this._fontSize = size;
-        this._android.setTextSize(Number(this._fontSize));
-    }
+    // [fontSizeProperty.setNative](size: number) {
+    //     this._fontSize = size;
+    //     this._android.setTextSize(Number(this._fontSize));
+    // }
 ​
     [markdownProperty.setNative](markdown: string) {
-        this._android.setTextSize(Number(this._fontSize));
+        console.log('Font Size', this.style.fontSize);
+        console.log('Font Size2', this.fontSize);
+        this._android.setTextSize(Number(this.fontSize));
         this.markwon.setMarkdown(this.nativeView, markdown);
     }
 ​

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -1,5 +1,6 @@
 import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
 import InputType = android.text.InputType;
+import { fontSizeProperty } from 'tns-core-modules/ui/styling/style-properties';
 
 ​
 declare var ru: any;
@@ -24,16 +25,12 @@ export class MarkdownView extends MarkdownViewBase {
         this._android.setInputType(InputType.TYPE_NULL);
         return this._android;
     }
-​
-    // [fontSizeProperty.setNative](size: number) {
-    //     this._fontSize = size;
-    //     this._android.setTextSize(Number(this._fontSize));
-    // }
-​
+
+    [fontSizeProperty.setNative](fontSize: number) {
+        this._android.setTextSize(Number(fontSize));
+    }
+
     [markdownProperty.setNative](markdown: string) {
-        console.log('Font Size', this.style.fontSize);
-        console.log('Font Size2', this.fontSize);
-        this._android.setTextSize(Number(this.fontSize));
         this.markwon.setMarkdown(this.nativeView, markdown);
     }
 ​

--- a/src/markdown-view.android.ts
+++ b/src/markdown-view.android.ts
@@ -1,6 +1,6 @@
 import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
 import InputType = android.text.InputType;
-import { fontSizeProperty } from 'tns-core-modules/ui/styling/style-properties';
+import { fontSizeProperty } from '@nativescript/core/ui/styling/style-properties';
 
 ​
 declare var ru: any;

--- a/src/markdown-view.common.ts
+++ b/src/markdown-view.common.ts
@@ -1,7 +1,8 @@
-import { Property } from 'tns-core-modules/ui/core/view';
-import {TextView} from "tns-core-modules/ui/text-view";
+import { CSSType, Property } from 'tns-core-modules/ui/core/view';
+import { Label } from 'tns-core-modules/ui/label';
 
-export class MarkdownViewBase extends TextView {
+@CSSType('MarkdownView')
+export class MarkdownViewBase extends Label {
 
     /**
      * Gets the native [android widget](http://developer.android.com/reference/android/widget/TextView.html) that represents the user interface for this component. Valid only when running on Android OS.
@@ -21,11 +22,4 @@ export const markdownProperty = new Property<MarkdownViewBase, string>({
     affectsLayout: true
 });
 
-export const fontSizeProperty = new Property<MarkdownViewBase, number>({
-    name: "fontSize",
-    defaultValue: 18,
-    affectsLayout: true
-});
-
 markdownProperty.register(MarkdownViewBase);
-fontSizeProperty.register(MarkdownViewBase);

--- a/src/markdown-view.common.ts
+++ b/src/markdown-view.common.ts
@@ -1,5 +1,5 @@
-import { CSSType, Property } from 'tns-core-modules/ui/core/view';
-import { Label } from 'tns-core-modules/ui/label';
+import { CSSType, Property } from '@nativescript/core/ui/core/view';
+import { Label } from '@nativescript/core/ui/label';
 
 @CSSType('MarkdownView')
 export class MarkdownViewBase extends Label {

--- a/src/markdown-view.ios.ts
+++ b/src/markdown-view.ios.ts
@@ -1,5 +1,5 @@
 import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
-import { fontSizeProperty } from 'tns-core-modules/ui/styling/style-properties';
+import { fontSizeProperty } from '@nativescript/core/ui/styling/style-properties';
 
 export class MarkdownView extends MarkdownViewBase {
 

--- a/src/markdown-view.ios.ts
+++ b/src/markdown-view.ios.ts
@@ -1,41 +1,47 @@
 import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
+import { fontSizeProperty } from 'tns-core-modules/ui/styling/style-properties';
 
 export class MarkdownView extends MarkdownViewBase {
 
     _ios: UITextView;
 
-    private _fontSize = 18;
+    mdParser: TSMarkdownParser;
+
+    _currentMarkdown: string;
 
     constructor() {
         super();
+
+        this.mdParser = TSMarkdownParser.standardParser();
     }
 
     public createNativeView() {
         this._ios = super.createNativeView() as UITextView;
+        this._ios.editable = false;
+        this._ios.selectable = true;
         return this._ios;
     }
 
-    // [fontSizeProperty.setNative](size: number) {
-    //     this._fontSize = size;
-    // }
-
-    [markdownProperty.setNative](markdown: string) {
-        const md = TSMarkdownParser.standardParser();
-        this._ios.editable = false;
-        this._ios.selectable = true;
-
+    [fontSizeProperty.setNative](fontSize: number) {
         const defaultAttributes =
-            NSDictionary.dictionaryWithObjectForKey(UIFont.systemFontOfSize(this._fontSize), NSFontAttributeName);
+            NSDictionary.dictionaryWithObjectForKey(UIFont.systemFontOfSize(fontSize), NSFontAttributeName);
         const emphasisAttributes =
-            NSDictionary.dictionaryWithObjectForKey(UIFont.italicSystemFontOfSize(this._fontSize), NSFontAttributeName);
+            NSDictionary.dictionaryWithObjectForKey(UIFont.italicSystemFontOfSize(fontSize), NSFontAttributeName);
         const strongAttributes =
-            NSDictionary.dictionaryWithObjectForKey(UIFont.boldSystemFontOfSize(this._fontSize), NSFontAttributeName);
+            NSDictionary.dictionaryWithObjectForKey(UIFont.boldSystemFontOfSize(fontSize), NSFontAttributeName);
 
-        md.defaultAttributes = defaultAttributes;
-        md.emphasisAttributes = emphasisAttributes;
-        md.strongAttributes = strongAttributes;
-
-        this._ios.attributedText = md.attributedStringFromMarkdown(markdown);
+        this.mdParser.defaultAttributes = defaultAttributes;
+        this.mdParser.emphasisAttributes = emphasisAttributes;
+        this.mdParser.strongAttributes = strongAttributes;
+        this._updateMarkdown();
     }
 
+    [markdownProperty.setNative](markdown: string) {
+        this._currentMarkdown = markdown;
+        this._updateMarkdown();
+    }
+
+    private _updateMarkdown() {
+        this._ios.attributedText = this.mdParser.attributedStringFromMarkdown(this._currentMarkdown);
+    }
 }

--- a/src/markdown-view.ios.ts
+++ b/src/markdown-view.ios.ts
@@ -1,4 +1,4 @@
-import { markdownProperty, fontSizeProperty, MarkdownViewBase } from './markdown-view.common';
+import { markdownProperty, MarkdownViewBase } from './markdown-view.common';
 
 export class MarkdownView extends MarkdownViewBase {
 
@@ -15,9 +15,9 @@ export class MarkdownView extends MarkdownViewBase {
         return this._ios;
     }
 
-    [fontSizeProperty.setNative](size: number) {
-        this._fontSize = size;
-    }
+    // [fontSizeProperty.setNative](size: number) {
+    //     this._fontSize = size;
+    // }
 
     [markdownProperty.setNative](markdown: string) {
         const md = TSMarkdownParser.standardParser();

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-markdown-view",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -22,6 +22,39 @@
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "@nativescript/core": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@nativescript/core/-/core-6.2.1.tgz",
+            "integrity": "sha512-OikbtbumuTSCSMcr7HFZUuzCmRkbIb4jGEzVfaCPdBFJBY9SOluYVACToPvqzK3T3NSCjhEZ3ao70ejF6Wrryg==",
+            "dev": true,
+            "requires": {
+                "nativescript-hook": "0.2.5",
+                "reduce-css-calc": "^2.1.6",
+                "semver": "6.3.0",
+                "tns-core-modules-widgets": "6.2.1",
+                "tslib": "1.10.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "tns-core-modules-widgets": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-6.2.1.tgz",
+                    "integrity": "sha512-rXzT74sUZd/TlfxZgyBAXimNbaFD49yOnY/0qobvF86OKuXeipwdIyLk1pzTUS5VPWZpvTL+azqtaFmpqyy5pw==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                    "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+                    "dev": true
+                }
             }
         },
         "ansi-styles": {
@@ -112,6 +145,12 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "css-unit-converter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+            "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
             "dev": true
         },
         "cycle": {
@@ -256,6 +295,31 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
+        "nativescript-hook": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.5.tgz",
+            "integrity": "sha512-ciGJtNbtMB2lGv8jAkUripkRjd3g8atX9VYPSt6e8PI6YPiOKeoma3xjcXoW66pFMYpHnfrbp6Mq9U/QtiQrVg==",
+            "dev": true,
+            "requires": {
+                "glob": "^6.0.1",
+                "mkdirp": "^0.5.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
         "ncp": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
@@ -289,6 +353,12 @@
             "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
             "dev": true
         },
+        "postcss-value-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+            "dev": true
+        },
         "prompt": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
@@ -310,6 +380,16 @@
             "dev": true,
             "requires": {
                 "mute-stream": "~0.0.4"
+            }
+        },
+        "reduce-css-calc": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.7.tgz",
+            "integrity": "sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==",
+            "dev": true,
+            "requires": {
+                "css-unit-converter": "^1.1.1",
+                "postcss-value-parser": "^3.3.0"
             }
         },
         "resolve": {
@@ -364,25 +444,18 @@
             }
         },
         "tns-core-modules": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.3.2.tgz",
-            "integrity": "sha512-as53Mo8BghhaRXxol+lEpFP1G5E5q/J8rj2f29PbPIa9vI9tn4leZHFqNlofKUYgqQ9P0XLC7hj6gl4WTzsvNw==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-6.2.1.tgz",
+            "integrity": "sha512-F8meLCzx0CxuBrigubCwQmTUF7lKyEX84D28uTSgPJnIkh8QnicUsvrNEcSul8n/mp9RggiB3AZtm26yZgaUvQ==",
             "dev": true,
             "requires": {
-                "tns-core-modules-widgets": "5.3.0",
-                "tslib": "^1.9.3"
+                "@nativescript/core": "6.2.1"
             }
         },
-        "tns-core-modules-widgets": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.3.0.tgz",
-            "integrity": "sha512-mR8Pof0NhMRhPYcshQ54WyPrlbrqmTgrwxALtF1485fbCAHblz/2DqU7yGmTgC5LNdV7yhNeHYouoYg3TYOZbA==",
-            "dev": true
-        },
         "tns-platform-declarations": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-5.3.2.tgz",
-            "integrity": "sha512-H9l54nH4IC4rV9VCl8uApM7xcHBujESVV2gldjZ7iGVPBL5mMk6ieRjLss1DjC122TMKE7R39bltPfnm2FmJxw==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-6.2.1.tgz",
+            "integrity": "sha512-7opb89Oeda6zRKqYgPrU95Cd+mO4KxwAxAVW/UFAH5ZSkALAIe2f/zTDUNvZYD4CV1/4DrzGVVsJphuBdMporA==",
             "dev": true
         },
         "tslib": {
@@ -422,9 +495,9 @@
             }
         },
         "typescript": {
-            "version": "3.3.4000",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-            "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
             "dev": true
         },
         "utile": {

--- a/src/package.json
+++ b/src/package.json
@@ -48,9 +48,10 @@
     "homepage": "https://github.com/flore2003/nativescript-markdown-view",
     "readmeFilename": "README.md",
     "devDependencies": {
-        "tns-core-modules": "^5.0.0",
-        "tns-platform-declarations": "^5.0.0",
-        "typescript": "~3.3.3",
+        "tns-core-modules": "6.2.1",
+        "@nativescript/core": "6.2.1",
+        "tns-platform-declarations": "^6.2.0",
+        "typescript": "~3.5.3",
         "prompt": "^1.0.0",
         "rimraf": "^2.6.3",
         "tslint": "^5.12.1",


### PR DESCRIPTION
## What is the current behavior?
Font size is handled through a custom property and is not available from CSS

## What is the new behavior?
Font size uses the NativeScript fontSize property and is available from CSS
